### PR TITLE
Set the NSLogger "domain" to the filename by default.

### DIFF
--- a/XCDLumberjackNSLogger.m
+++ b/XCDLumberjackNSLogger.m
@@ -60,6 +60,12 @@ static void SetThreadNameWithMessage(DDLogMessage *logMessage)
 {
 	int level = log2f(logMessage.flag);
 	NSString *tag = self.tags[@(logMessage.context)];
+
+	// Set tag to fileName by default
+	if (!tag) {
+		tag = logMessage.fileName;
+	}
+
 	NSData *data = MessageAsData(logMessage.message);
 	SetThreadNameWithMessage(logMessage);
 	if (data)


### PR DESCRIPTION
I am just switching over from [NSLogger-CocoaLumberjack-connector](https://github.com/steipete/NSLogger-CocoaLumberjack-connector) It is great to have accurate thread info, so thanks for this!

One thing I was missing is the way the old connector would automatically set the NSLogger _domain_ to be the filename.  So here's my attempt to restore that functionality.  
## Before

<img width="571" alt="before" src="https://cloud.githubusercontent.com/assets/9273562/13016526/4c8646fa-d18d-11e5-8130-d09e471e117e.png">
## After

<img width="548" alt="after" src="https://cloud.githubusercontent.com/assets/9273562/13016544/6b1be62e-d18d-11e5-97a9-4fb9cb9ab8bc.png">
